### PR TITLE
Fix crash on selecting a second time

### DIFF
--- a/src/multiselect_controls.js
+++ b/src/multiselect_controls.js
@@ -392,7 +392,7 @@ export class MultiselectControls {
     this.dragSelect_.subscribe('elementselect', (info) => {
       const element = info.item.parentElement;
       if (inMultipleSelectionModeWeakMap.get(this.workspace_) &&
-          element.dataset && element.dataset.id) {
+          element && element.dataset && element.dataset.id) {
         this.updateBlocks_(
             this.workspace_.getBlockById(element.dataset.id));
       }
@@ -400,7 +400,7 @@ export class MultiselectControls {
     this.dragSelect_.subscribe('elementunselect', (info) => {
       const element = info.item.parentElement;
       if (inMultipleSelectionModeWeakMap.get(this.workspace_) &&
-          element.dataset && element.dataset.id) {
+          element && element.dataset && element.dataset.id) {
         this.updateBlocks_(
             this.workspace_.getBlockById(element.dataset.id));
       }


### PR DESCRIPTION
This handles the case where `element` does not exist. This fixes the crash, but I'm not familiar enough with the code base to know if this should have any side effects.

To reproduce:
- Select `Zelos` renderer. It does not appear to happen with other renderers.
- Select a few blocks with `shift` key held down.
- Release `shift`, then press again to repeat selection.
- Observe crash:

https://github.com/laurensvalk/workspace-multiselect/assets/12326241/7579c7ab-c0fa-4079-ab73-d12ccd12ee9a


